### PR TITLE
Add RISC-V machine id

### DIFF
--- a/lib/elf.rb
+++ b/lib/elf.rb
@@ -237,6 +237,7 @@ module Elf
            189 => [ :MicroBlaze, 'Xilinx MicroBlaze 32-bit RISC soft processor core' ],
            190 => [ :CUDA, 'NVIDIA CUDA architecture' ],
            191 => [ :TILEGx, 'Tilera TILE-Gx' ],
+           243 => [ :RISCV, 'RISC-V' ],
 
            0x9026 => [ :Alpha, 'DEC Alpha' ]
          )


### PR DESCRIPTION
Hi folks,

Today I was trying to inspect a RV32I binary with this gem and I noticed RISC-V was not supported.

See below the error I found and the attached commit that should add support for RISC-V architecture in this gem.

Thanks!

```
ubuntu@ip-172-31-4-62:~$ irb
irb(main):001:0> require "elf"
/home/ubuntu/.gem/ruby/3.2.0/gems/ruby-elf-1.0.8/lib/elf.rb:199: warning: key 135 is duplicated and overwritten on line 200
/home/ubuntu/.gem/ruby/3.2.0/gems/ruby-elf-1.0.8/lib/elf.rb:216: warning: key 168 is duplicated and overwritten on line 217
=> true                                                                       
irb(main):002:0> file = Elf::File.new("/opt/riscv/target/share/riscv-tests/isa/rv32ui-p-add")
/home/ubuntu/.gem/ruby/3.2.0/gems/ruby-elf-1.0.8/lib/elf/file.rb:198:in `rescue in initialize': Invalid Elf machine 243 (Elf::File::InvalidMachine)
        from /home/ubuntu/.gem/ruby/3.2.0/gems/ruby-elf-1.0.8/lib/elf/file.rb:195:in `initialize'
        from (irb):2:in `new'                                                 
        from (irb):2:in `<main>'                                              
        from /home/ubuntu/.rubies/ruby-3.2.0/lib/ruby/gems/3.2.0/gems/irb-1.6.2/exe/irb:11:in `<top (required)>'
        from /home/ubuntu/.rubies/ruby-3.2.0/bin/irb:25:in `load'             
        from /home/ubuntu/.rubies/ruby-3.2.0/bin/irb:25:in `<main>'           
/home/ubuntu/.gem/ruby/3.2.0/gems/ruby-elf-1.0.8/lib/elf/value.rb:73:in `[]': Value 243 out of bound (Elf::Value::OutOfBound)
        from /home/ubuntu/.gem/ruby/3.2.0/gems/ruby-elf-1.0.8/lib/elf/file.rb:196:in `initialize'
        from (irb):2:in `new'                                                 
        from (irb):2:in `<main>'                                              
        from /home/ubuntu/.rubies/ruby-3.2.0/lib/ruby/gems/3.2.0/gems/irb-1.6.2/exe/irb:11:in `<top (required)>'
        from /home/ubuntu/.rubies/ruby-3.2.0/bin/irb:25:in `load'             
        from /home/ubuntu/.rubies/ruby-3.2.0/bin/irb:25:in `<main>'           
irb(main):003:0> 
```